### PR TITLE
Add support for Mac OS 12

### DIFF
--- a/install-wheel-rs/src/wheel_tags.rs
+++ b/install-wheel-rs/src/wheel_tags.rs
@@ -742,7 +742,7 @@ mod test {
         assert_eq!(
             vec![
                 "numpy-1.22.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                "tqdm-4.62.3-py2.py3-none-any.whl",
+                "tqdm-4.62.3-py2.py3-none-any.whl"
             ],
             compatible
         );

--- a/install-wheel-rs/src/wheel_tags.rs
+++ b/install-wheel-rs/src/wheel_tags.rs
@@ -709,7 +709,6 @@ mod test {
 
         for (filename, (python_version, os, arch)) in filenames {
             let compatible_tags = compatible_tags(python_version, &os, &arch)?;
-            println!("{:?}", compatible_tags);
             assert!(
                 WheelFilename::from_str(filename)?.is_compatible(&compatible_tags),
                 "{}",

--- a/install-wheel-rs/src/wheel_tags.rs
+++ b/install-wheel-rs/src/wheel_tags.rs
@@ -244,7 +244,7 @@ impl Os {
                 return Err(WheelInstallerError::OsVersionDetectionError(format!(
                     "The operating system {:?} is not supported",
                     unsupported
-                )));
+                )))
             }
         };
         Ok(os)


### PR DESCRIPTION
This PR adds support for Mac OS 12 and, in particular, modifies the "compatible tag" logic for Mac OS to better match that of the `packaging` module.

You can find the reference source code [here](https://github.com/pypa/packaging/blob/fd4f11139d1c884a637be8aa26bb60a31fbc9411/packaging/tags.py#L346) and [here](https://github.com/pypa/packaging/blob/fd4f11139d1c884a637be8aa26bb60a31fbc9411/packaging/tags.py#L314).

# Test Plan

Used `install-wheel-rs` to install `ruff-0.0.63-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl` locally, which previously failed.
