### PR TITLE
Implement install requirements.txt cli

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,7 +125,7 @@ Installing a single large wheel (plotly)
 ```
 $ virtualenv --clear .venv-benchmark
 $ VIRTUAL_ENV=.venv-benchmark hyperfine -p ".venv-benchmark/bin/pip uninstall -y plotly" \
-  "target/release/monotrail venv-install test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl" \
+  "target/release/monotrail wheel-install test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl" \
   ".venv-benchmark/bin/pip install --no-deps test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl"
           
 Benchmark #1: target/release/monotrail install test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl

--- a/flamegraph.sh
+++ b/flamegraph.sh
@@ -2,5 +2,5 @@
 
 rm -rf test-venvs/benchmark
 virtualenv test-venvs/benchmark
-VIRTUAL_ENV=test-venvs/benchmark flamegraph -o flamegraph_plotly.svg -- target/release/monotrail venv-install --no-compile test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl
-VIRTUAL_ENV=test-venvs/benchmark flamegraph -o flamegraph_popular.svg -- target/release/monotrail venv-install --no-compile test-data/popular-wheels/*
+VIRTUAL_ENV=test-venvs/benchmark flamegraph -o flamegraph_plotly.svg -- target/release/monotrail wheel-install --no-compile test-data/popular-wheels/plotly-5.5.0-py2.py3-none-any.whl
+VIRTUAL_ENV=test-venvs/benchmark flamegraph -o flamegraph_popular.svg -- target/release/monotrail wheel-install --no-compile test-data/popular-wheels/*

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -584,19 +584,24 @@ pub fn find_venv(venv: Option<&Path>) -> anyhow::Result<PathBuf> {
 mod test {
     use super::install;
     use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
 
     #[test]
-    fn test_install() {
+    fn test_install() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let venv = temp_dir.path().join(".venv");
+        Command::new("virtualenv").arg(&venv).output()?;
         let working_dir = Path::new("test-data").join("requirements-txt");
         let small = working_dir.join("small.txt");
         install(
-            vec![small.to_str().unwrap().to_string()],
+            &[small.to_str().unwrap().to_string()],
             false,
             false,
             true,
-            None,
+            Some(&venv),
             Some(&working_dir),
-        )
-        .unwrap();
+        )?;
+        Ok(())
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use crate::package_index::download_distribution;
 use crate::poetry_integration::read_dependencies::{read_poetry_specs, read_toml_files};
 use crate::poetry_integration::run::poetry_run;
 use crate::ppipx;
+use crate::requirements_txt::RequirementsTxt;
 use crate::spec::RequestedSpec;
 use crate::utils::cache_dir;
 use crate::venv_parser::get_venv_python_version;
@@ -16,6 +17,7 @@ use install_wheel_rs::{compatible_tags, Arch, InstallLocation, Os, WheelInstalle
 use pep440_rs::Operator;
 use pep508_rs::VersionOrUrl;
 use std::env;
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tracing::{debug, info};

--- a/src/install.rs
+++ b/src/install.rs
@@ -156,7 +156,7 @@ pub fn install_all(
     specs: &[RequestedSpec],
     location: &InstallLocation<LockedDir>,
     compatible_tags: &[(String, String, String)],
-    no_compile: bool,
+    compile: bool,
     background: bool,
     no_parallel: bool,
 ) -> anyhow::Result<Vec<InstalledPackage>> {
@@ -177,7 +177,7 @@ pub fn install_all(
                 spec,
                 &location,
                 compatible_tags,
-                no_compile,
+                compile,
                 &location.get_python(),
             )?;
             debug!(
@@ -220,7 +220,7 @@ pub fn install_all(
                     spec,
                     &location,
                     compatible_tags,
-                    no_compile,
+                    compile,
                     &location.get_python(),
                 )?;
                 debug!(
@@ -356,7 +356,7 @@ fn download_and_install(
     requested_spec: &RequestedSpec,
     location: &InstallLocation<LockedDir>,
     compatible_tags: &[(String, String, String)],
-    no_compile: bool,
+    compile: bool,
     sys_executable: &Path,
 ) -> anyhow::Result<(String, String, String)> {
     let spec = requested_spec.resolve(PYPI_HOST, compatible_tags)?;
@@ -434,7 +434,7 @@ fn download_and_install(
     let tag = install_wheel(
         location,
         &wheel_path,
-        !no_compile,
+        compile,
         &spec.extras,
         &spec.unique_version,
         &sys_executable,

--- a/src/monotrail.rs
+++ b/src/monotrail.rs
@@ -118,16 +118,17 @@ pub fn monotrail_root() -> anyhow::Result<PathBuf> {
 /// Walks the directory tree up to find a pyproject.toml or a requirements.txt and returns
 /// the dir (poetry) or the file (requirements.txt)
 fn find_dep_file(dir_running: &Path) -> Option<(PathBuf, LockfileType)> {
-    let mut parent = Some(dir_running.to_path_buf());
-    while let Some(dir) = parent {
-        if dir.join("poetry.lock").exists() {
-            return Some((dir, LockfileType::PoetryLock));
-        } else if dir.join("pyproject.toml").exists() {
-            return Some((dir, LockfileType::PyprojectToml));
-        } else if dir.join("requirements.txt").exists() {
-            return Some((dir.join("requirements.txt"), LockfileType::RequirementsTxt));
+    for ancestor in dir_running.ancestors() {
+        if ancestor.join("poetry.lock").exists() {
+            return Some((ancestor.to_path_buf(), LockfileType::PoetryLock));
+        } else if ancestor.join("pyproject.toml").exists() {
+            return Some((ancestor.to_path_buf(), LockfileType::PyprojectToml));
+        } else if ancestor.join("requirements.txt").exists() {
+            return Some((
+                ancestor.join("requirements.txt"),
+                LockfileType::RequirementsTxt,
+            ));
         }
-        parent = dir.parent().map(|path| path.to_path_buf());
     }
     None
 }

--- a/src/requirements_txt.rs
+++ b/src/requirements_txt.rs
@@ -78,6 +78,20 @@ pub struct RequirementEntry {
     pub editable: bool,
 }
 
+impl Display for RequirementEntry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.editable {
+            write!(f, "-e ")?;
+        }
+        write!(f, "{}", self.requirement)?;
+        for hash in &self.hashes {
+            write!(f, " --hash {}", hash)?
+        }
+
+        Ok(())
+    }
+}
+
 /// Parsed and flattened requirements.txt with requirements and constraints
 #[derive(Debug, Deserialize, Clone, Default, Eq, PartialEq, Serialize)]
 pub struct RequirementsTxt {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -32,10 +32,14 @@ pub struct SpecSource {
 /// TODO: carry hashes/locked files
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RequestedSpec {
+    /// Will be printed with the error message to indicate what was tried to install
     pub requested: String,
+    /// The name of the package
     pub name: String,
+    /// The version of the package
     pub python_version: Option<String>,
     pub source: Option<SpecSource>,
+    /// The extras of the package to also be installed
     pub extras: Vec<String>,
     /// TODO: allow sdist filepath
     pub file_path: Option<(PathBuf, WheelFilename)>,

--- a/test-data/requirements-txt/small.json
+++ b/test-data/requirements-txt/small.json
@@ -1,0 +1,15 @@
+{
+  "requirements": [
+    {
+      "requirement": "tqdm ==4.65.0",
+      "hashes": [],
+      "editable": false
+    },
+    {
+      "requirement": "tomli-w ==1.0.0",
+      "hashes": [],
+      "editable": false
+    }
+  ],
+  "constraints": []
+}

--- a/test-data/requirements-txt/small.txt
+++ b/test-data/requirements-txt/small.txt
@@ -1,0 +1,4 @@
+# These are small and fast to install
+
+tqdm==4.65.0
+tomli-w==1.0.0

--- a/test/install/test_compare_pip.py
+++ b/test/install/test_compare_pip.py
@@ -51,7 +51,7 @@ def compare_with_pip(
     check_call(["virtualenv", env], stdout=DEVNULL)
     start_rs = time.time()
     check_call(
-        [monotrail, "venv-install", *wheels],
+        [monotrail, "wheel-install", *wheels],
         env=dict(os.environ, VIRTUAL_ENV=str(env)),
     )
     stop_rs = time.time()

--- a/test/install/test_tqdm.py
+++ b/test/install/test_tqdm.py
@@ -42,7 +42,7 @@ def test_tqdm():
         .joinpath("popular-wheels")
         .joinpath("tqdm-4.62.3-py2.py3-none-any.whl")
     )
-    check_call([get_bin(), "venv-install", tqdm_wheel], env=env)
+    check_call([get_bin(), "wheel-install", tqdm_wheel], env=env)
     check_call(
         [
             python,

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -15,7 +15,7 @@ fn check_error(name: &str, expected: &[&str]) -> Result<()> {
     Command::new("virtualenv").arg(&venv).output()?;
     let wheel = Path::new("test-data").join("pip-test-packages").join(name);
     let cli: Cli =
-        Cli::try_parse_from(["monotrail", "venv-install", &wheel.display().to_string()])?;
+        Cli::try_parse_from(["monotrail", "wheel-install", &wheel.display().to_string()])?;
     assert_cli_error(cli, Some(&venv), expected);
     Ok(())
 }


### PR DESCRIPTION
Adds a very basic CLI to install from requirements.txt the same way that pip does. Works the same as pip for pydantic's `all.txt` for part i diffed. I've split the test refactoring necessary one stack up, not sure yet if that makes sense.
