### PR TITLE
Add pydantics requirements all.txt test

### DIFF
--- a/install-wheel-rs/src/wheel.rs
+++ b/install-wheel-rs/src/wheel.rs
@@ -123,8 +123,8 @@ pub fn get_script_launcher(module: &str, import_name: &str, shebang: &str) -> St
 import re
 import sys
 from {module} import {import_name}
-if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+if __name__ == "__main__":
+    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
     sys.exit({import_name}())
 "##,
         shebang = shebang,

--- a/install-wheel-rs/src/wheel_tags.rs
+++ b/install-wheel-rs/src/wheel_tags.rs
@@ -82,7 +82,8 @@ impl WheelFilename {
     }
 }
 
-/// Returns the compatible tags in a (python_tag, abi_tag, platform_tag) format
+/// Returns the compatible tags in a (python_tag, abi_tag, platform_tag) format, ordered from
+/// highest precedence to lowest precedence
 pub fn compatible_tags(
     python_version: (u8, u8),
     os: &Os,

--- a/test/install/test_compare_pip.py
+++ b/test/install/test_compare_pip.py
@@ -6,22 +6,43 @@ import shutil
 import sys
 import time
 from argparse import ArgumentParser
+from filecmp import cmpfiles
 from pathlib import Path
 from shutil import rmtree
 from subprocess import check_call, DEVNULL
-from typing import List, Union
+from typing import List, Union, Optional, Set
 
 import pytest
 
 from test.install.utils import get_bin, get_root
 
 
-def compare_with_pip(
+def compare_with_pip_wheels(
     env_name: str,
     wheels: List[Union[str, Path]],
-    monotrail: Path,
+    monotrail: Path = get_bin(),
     clear_rs: bool = True,
     clear_pip: bool = False,
+):
+    compare_with_pip_args(
+        env_name,
+        ["--no-deps", *wheels],
+        ["wheel-install", *wheels],
+        monotrail,
+        clear_rs,
+        clear_pip,
+    )
+
+
+def compare_with_pip_args(
+    env_name: str,
+    pip_args: List[Union[str, Path]],
+    monotrail_args: List[Union[str, Path]],
+    monotrail: Path = get_bin(),
+    clear_rs: bool = True,
+    clear_pip: bool = False,
+    cwd: Optional[Path] = None,
+    content_diff_exclusions: Optional[Set[Path]] = None,
 ):
     test_venvs = get_root().joinpath("test-venvs")
     test_venvs.mkdir(exist_ok=True)
@@ -33,13 +54,13 @@ def compare_with_pip(
     if clear_pip and env_py.exists():
         rmtree(env_py)
     if not env_py.exists():
-        check_call(["virtualenv", env], stdout=DEVNULL)
+        check_call(["virtualenv", env], stdout=DEVNULL, cwd=cwd)
         start_pip = time.time()
         if platform.system() == "Windows":
             pip = env.joinpath("Scripts").joinpath("pip.exe")
         else:
             pip = env.joinpath("bin").joinpath("pip")
-        check_call([pip, "install", "-q", "--no-deps", *wheels])
+        check_call([pip, "install", "-q", *pip_args], cwd=cwd)
         stop_pip = time.time()
         env.rename(env_py)
 
@@ -51,8 +72,9 @@ def compare_with_pip(
     check_call(["virtualenv", env], stdout=DEVNULL)
     start_rs = time.time()
     check_call(
-        [monotrail, "wheel-install", *wheels],
+        [monotrail, *monotrail_args],
         env=dict(os.environ, VIRTUAL_ENV=str(env)),
+        cwd=cwd,
     )
     stop_rs = time.time()
     env.rename(env_rs)
@@ -60,35 +82,52 @@ def compare_with_pip(
 
     print(f"{env_name} rs install took {rust_time :.2f}s")
 
-    diff_envs(env_name, env_py, env_rs)
+    diff_envs(env_name, env_py, env_rs, content_diff_exclusions=content_diff_exclusions)
 
     if clear_rs:
         shutil.rmtree(env_rs)
 
 
-def diff_envs(env_name: str, env_py: Path, env_rs: Path):
-    # Filter out paths created by invoking pip and pip itself with on oh horrible regex
+def diff_envs(
+    env_name: str,
+    env_py: Path,
+    env_rs: Path,
+    content_diff_exclusions: Optional[Set[Path]] = None,
+):
+    """Compare the contents of two virtualenvs, one filled by our implementation and one
+    filled by pip, poetry or another python tool we want to compare. Both were renamed
+    from the same dir so all path inside are the same.
+     * List all files and directories in both virtualenvs
+     * Filter out all files and folder that are known to diverge
+     * Check that the remaining file lists are identical
+     * Filter our all directories and all files known to have different contents such
+       as `INSTALLER`
+     * Read the contents from both the rs and pip env, normalize quotation marks and
+       newline
+     * Check that the file contents are identical
+    """
+    # Filter out paths created by invoking pip and pip itself with a horrible regex
     # Better matching suggestions welcome 😬
     site_ignores = [
-        r"__pycache__",
-        r"pip",
-        r"pip-[^/]+.dist-info",
-        r"setuptools",
-        r"pkg_resources",
-        r"_distutils_hack/__pycache__",
+        "__pycache__",
+        "pip",
+        "pip-" + "[^/]+" + re.escape(".dist-info"),
+        "setuptools",
+        "pkg_resources",
+        "_distutils_hack/__pycache__",
         # Doesn't make sense in our case to enforce this strictly
-        r"[a-zA-Z0-9\.\-_]+\.dist-info/direct_url.json",
+        "[a-zA-Z0-9._-]+" + re.escape(".dist-info/direct_url.json"),
         # poetry doesn't seem to do this (we do currently)
-        r"[a-zA-Z0-9\.\-_]+\.dist-info/REQUESTED",
+        "[a-zA-Z0-9._-]+" + re.escape(".dist-info/REQUESTED"),
     ]
     if platform.system() == "Windows":
         site_packages = "Lib/site-packages/"
     else:
-        py_version = rf"{sys.version_info.major}\.{sys.version_info.minor}"
+        py_version = rf"{sys.version_info.major}.{sys.version_info.minor}"
         site_packages = rf"lib/python{py_version}/site-packages/"
     pattern = (
         "^("
-        + site_packages
+        + re.escape(site_packages)
         + "("
         + "|".join(site_ignores)
         + ")"
@@ -111,9 +150,69 @@ def diff_envs(env_name: str, env_py: Path, env_rs: Path):
         env_py_entries.add(i.relative_to(env_py))
     symmetric_difference = env_rs_entries ^ env_py_entries
     if symmetric_difference:
-        print("PATTERN", pattern)
-        print("DIFF", env_name, symmetric_difference)
+        print(f"Differences in environment {env_name} with pattern {pattern}")
+        for rs_only in env_rs_entries - env_py_entries:
+            print(f"rust only: {rs_only}")
+        for pip_only in env_py_entries - env_rs_entries:
+            print(f"pip only: {pip_only}")
         sys.exit(1)
+
+    start = time.time()
+    # Filter out directories and files known to have diverging contents
+    common = []
+    for entry in env_rs_entries:
+        if env_py.joinpath(entry).is_dir():
+            continue
+        # Used for source distribution
+        if content_diff_exclusions and entry in content_diff_exclusions:
+            continue
+        # Ignore INSTALLER and subsequently RECORD
+        # TODO(konstin): Use RECORD checker from monotrail on both
+        if str(entry).startswith(site_packages):
+            in_python_path = Path(str(entry).replace(site_packages, "", 1))
+            if len(in_python_path.parts) == 2:
+                [folder, file] = in_python_path.parts
+                if folder.endswith(".dist-info") and file in ["INSTALLER", "RECORD"]:
+                    continue
+
+        common.append(entry)
+
+    # Fast path for the majority of files that is byte-by-bytes identical
+    _match, mismatch, errors = cmpfiles(env_py, env_rs, common)
+
+    assert not errors, errors
+
+    # Slow path to compare files again after some normalization
+    diverging = []
+    for entry in mismatch:
+        # Ignore platform newline differences
+        content_py = env_py.joinpath(entry).read_bytes().replace(b"\r", b"")
+        content_rs = env_rs.joinpath(entry).read_bytes().replace(b"\r", b"")
+
+        # These depend on the tool versions, make them equal across versions
+        if (platform.system() == "Windows" and entry.parent.name == "Scripts") or (
+            platform.system() != "Windows" and entry.parent.name == "bin"
+        ):
+            content_py = content_py.replace(b"'", b'"')
+            content_rs = content_rs.replace(b"'", b'"')
+
+        if content_py != content_rs:
+            diverging.append(entry)
+    end = time.time()
+    # This is currently slow, remove this print once it is fast
+    print(f"Comparing files took {end - start:.2f}")
+
+    if diverging:
+        for path in diverging:
+            # clickable links for debugging
+            print(f"# {path}\n", file=sys.stderr)
+            print(
+                f"{env_py.joinpath(path).relative_to(os.getcwd())}:1", file=sys.stderr
+            )
+            print(
+                f"{env_rs.joinpath(path).relative_to(os.getcwd())}:1", file=sys.stderr
+            )
+        raise AssertionError(f"Diverging path:\n{diverging}")
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="linux only wheel")
@@ -121,7 +220,7 @@ def test_purelib_platlib():
     purelib_platlib_wheel = get_root().joinpath(
         "test-data/wheels/purelib_and_platlib-1.0.0-cp38-cp38-linux_x86_64.whl"
     )
-    compare_with_pip("purelib_platlib", [purelib_platlib_wheel], get_bin())
+    compare_with_pip_wheels("purelib_platlib", [purelib_platlib_wheel], get_bin())
 
 
 def test_tqdm():
@@ -131,7 +230,7 @@ def test_tqdm():
         .joinpath("popular-wheels")
         .joinpath("tqdm-4.62.3-py2.py3-none-any.whl")
     )
-    compare_with_pip("tqdm", [purelib_platlib_wheel], get_bin())
+    compare_with_pip_wheels("tqdm", [purelib_platlib_wheel], get_bin())
 
 
 def test_scripts_ignore_extras():
@@ -141,7 +240,7 @@ def test_scripts_ignore_extras():
         .joinpath("wheels")
         .joinpath("miniblack-23.1.0-py3-none-any.whl")
     )
-    compare_with_pip("miniblack", [miniblack], get_bin())
+    compare_with_pip_wheels("miniblack", [miniblack], get_bin())
 
 
 def test_bio_embeddings_plus():
@@ -149,7 +248,9 @@ def test_bio_embeddings_plus():
     bio_embeddings_plus_wheel = get_root().joinpath(
         "test-data/wheels/bio_embeddings_PLUS-0.1.1-py3-none-any.whl"
     )
-    compare_with_pip("bio_embeddings_plus", [bio_embeddings_plus_wheel], get_bin())
+    compare_with_pip_wheels(
+        "bio_embeddings_plus", [bio_embeddings_plus_wheel], get_bin()
+    )
 
 
 def main():
@@ -160,7 +261,7 @@ def main():
     wheel = Path(args.wheel)
 
     env_name = wheel.name.split("-")[0]
-    compare_with_pip(env_name, [wheel], get_bin())
+    compare_with_pip_wheels(env_name, [wheel], get_bin())
 
 
 if __name__ == "__main__":

--- a/test/install/test_compare_pip.py
+++ b/test/install/test_compare_pip.py
@@ -20,7 +20,8 @@ from test.install.utils import get_bin, get_root
 def compare_with_pip_wheels(
     env_name: str,
     wheels: List[Union[str, Path]],
-    monotrail: Path = get_bin(),
+    *,
+    monotrail: Optional[Path] = None,
     clear_rs: bool = True,
     clear_pip: bool = False,
 ):
@@ -28,9 +29,9 @@ def compare_with_pip_wheels(
         env_name,
         ["--no-deps", *wheels],
         ["wheel-install", *wheels],
-        monotrail,
-        clear_rs,
-        clear_pip,
+        monotrail=monotrail,
+        clear_rs=clear_rs,
+        clear_pip=clear_pip,
     )
 
 
@@ -38,7 +39,8 @@ def compare_with_pip_args(
     env_name: str,
     pip_args: List[Union[str, Path]],
     monotrail_args: List[Union[str, Path]],
-    monotrail: Path = get_bin(),
+    *,
+    monotrail: Optional[Path] = None,
     clear_rs: bool = True,
     clear_pip: bool = False,
     cwd: Optional[Path] = None,
@@ -70,6 +72,7 @@ def compare_with_pip_args(
     if env_rs.exists():
         rmtree(env_rs)
     check_call(["virtualenv", env], stdout=DEVNULL)
+    monotrail = monotrail or get_bin()
     start_rs = time.time()
     check_call(
         [monotrail, *monotrail_args],
@@ -220,7 +223,7 @@ def test_purelib_platlib():
     purelib_platlib_wheel = get_root().joinpath(
         "test-data/wheels/purelib_and_platlib-1.0.0-cp38-cp38-linux_x86_64.whl"
     )
-    compare_with_pip_wheels("purelib_platlib", [purelib_platlib_wheel], get_bin())
+    compare_with_pip_wheels("purelib_platlib", [purelib_platlib_wheel])
 
 
 def test_tqdm():
@@ -230,7 +233,7 @@ def test_tqdm():
         .joinpath("popular-wheels")
         .joinpath("tqdm-4.62.3-py2.py3-none-any.whl")
     )
-    compare_with_pip_wheels("tqdm", [purelib_platlib_wheel], get_bin())
+    compare_with_pip_wheels("tqdm", [purelib_platlib_wheel])
 
 
 def test_scripts_ignore_extras():
@@ -240,7 +243,7 @@ def test_scripts_ignore_extras():
         .joinpath("wheels")
         .joinpath("miniblack-23.1.0-py3-none-any.whl")
     )
-    compare_with_pip_wheels("miniblack", [miniblack], get_bin())
+    compare_with_pip_wheels("miniblack", [miniblack])
 
 
 def test_bio_embeddings_plus():
@@ -248,9 +251,7 @@ def test_bio_embeddings_plus():
     bio_embeddings_plus_wheel = get_root().joinpath(
         "test-data/wheels/bio_embeddings_PLUS-0.1.1-py3-none-any.whl"
     )
-    compare_with_pip_wheels(
-        "bio_embeddings_plus", [bio_embeddings_plus_wheel], get_bin()
-    )
+    compare_with_pip_wheels("bio_embeddings_plus", [bio_embeddings_plus_wheel])
 
 
 def main():
@@ -261,7 +262,7 @@ def main():
     wheel = Path(args.wheel)
 
     env_name = wheel.name.split("-")[0]
-    compare_with_pip_wheels(env_name, [wheel], get_bin())
+    compare_with_pip_wheels(env_name, [wheel])
 
 
 if __name__ == "__main__":

--- a/test/install/test_compare_poetry.py
+++ b/test/install/test_compare_poetry.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from shutil import rmtree
 from subprocess import check_call, DEVNULL, CalledProcessError
-from typing import List
+from typing import List, Optional
 
 from test.install.test_compare_pip import diff_envs
 from test.install.utils import get_bin, get_root
@@ -17,9 +17,10 @@ from test.install.utils import get_bin, get_root
 def compare_with_poetry(
     env_base: str,
     project_dir: Path,
-    monotrail: Path,
     no_dev: bool,
     extras: List[str],
+    *,
+    monotrail: Optional[Path] = None,
     clear_rs: bool = True,
     clear_poetry: bool = False,
 ):
@@ -64,6 +65,7 @@ def compare_with_poetry(
     if env_rs.exists():
         rmtree(env_rs)
     check_call(["virtualenv", env], stdout=DEVNULL)
+    monotrail = monotrail or get_bin()
     start_rs = time.time()
     call = [monotrail, "poetry-install"]
     if no_dev:
@@ -92,7 +94,6 @@ def test_data_science_project():
     compare_with_poetry(
         "data_science_project",
         get_root().joinpath("data_science_project"),
-        get_bin(),
         False,
         ["tqdm_feature"],
     )
@@ -107,9 +108,7 @@ def main():
 
     project_dir = Path(args.project_dir)
 
-    compare_with_poetry(
-        project_dir.name, project_dir, get_bin(), args.no_dev, args.extras
-    )
+    compare_with_poetry(project_dir.name, project_dir, args.no_dev, args.extras)
 
 
 if __name__ == "__main__":

--- a/test/install/test_monotrail_install_frozen.py
+++ b/test/install/test_monotrail_install_frozen.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from test.install.test_compare_pip import compare_with_pip_args
+
+
+def test_pydantic(pytestconfig):
+    root = pytestconfig.rootpath
+    requirements_all_txt = "test-data/requirements-pydantic/all.txt"
+    # source distributions, the contents of these lines depend on the build env
+    content_diff_exclusions = {
+        Path("lib/python3.8/site-packages/mkdocs_exclude-1.0.2.dist-info/METADATA"),
+        Path("lib/python3.8/site-packages/mkdocs_exclude-1.0.2.dist-info/WHEEL"),
+        Path(
+            "lib/python3.8/site-packages/mkdocs_exclude-1.0.2.dist-info/entry_points.txt"
+        ),
+        Path("lib/python3.8/site-packages/mkdocs_redirects-1.2.0.dist-info/METADATA"),
+        Path("lib/python3.8/site-packages/mkdocs_redirects-1.2.0.dist-info/WHEEL"),
+        Path(
+            "lib/python3.8/site-packages/mkdocs_redirects-1.2.0.dist-info/entry_points.txt"
+        ),
+    }
+    compare_with_pip_args(
+        env_name="monotrail_install_frozen_pydantic",
+        pip_args=["--no-deps", "--no-compile", "-r", requirements_all_txt],
+        monotrail_args=["install", "--frozen", "-r", requirements_all_txt],
+        cwd=root,
+        content_diff_exclusions=content_diff_exclusions,
+    )

--- a/test/install/test_piptests.py
+++ b/test/install/test_piptests.py
@@ -4,11 +4,10 @@ Use the wheels from pip's tests to cover the edge cases
 """
 
 from test.install.test_compare_pip import compare_with_pip_wheels
-from test.install.utils import get_bin, get_root
+from test.install.utils import get_root
 
 
 def test_piptests():
-    bin = get_bin()
     wheel_paths = list(
         get_root().joinpath("test-data/pip-test-packages/").glob("*.whl")
     )
@@ -26,7 +25,7 @@ def test_piptests():
         wheel_paths.remove(
             get_root().joinpath("test-data/pip-test-packages/").joinpath(invalid)
         )
-    compare_with_pip_wheels("venv-piptests", wheel_paths, bin)
+    compare_with_pip_wheels("venv-piptests", wheel_paths)
 
 
 if __name__ == "__main__":

--- a/test/install/test_piptests.py
+++ b/test/install/test_piptests.py
@@ -3,7 +3,7 @@
 Use the wheels from pip's tests to cover the edge cases
 """
 
-from test.install.test_compare_pip import compare_with_pip
+from test.install.test_compare_pip import compare_with_pip_wheels
 from test.install.utils import get_bin, get_root
 
 
@@ -26,7 +26,7 @@ def test_piptests():
         wheel_paths.remove(
             get_root().joinpath("test-data/pip-test-packages/").joinpath(invalid)
         )
-    compare_with_pip("venv-piptests", wheel_paths, bin)
+    compare_with_pip_wheels("venv-piptests", wheel_paths, bin)
 
 
 if __name__ == "__main__":

--- a/test/install/test_popular.py
+++ b/test/install/test_popular.py
@@ -4,7 +4,7 @@ Test with the top 100 pypi wheels and some more
 """
 from subprocess import check_call
 
-from test.install.test_compare_pip import compare_with_pip
+from test.install.test_compare_pip import compare_with_pip_wheels
 from test.install.utils import get_bin, get_root
 
 
@@ -24,7 +24,7 @@ def test_popular():
         )
     bin = get_bin()
     wheels_paths = list(wheels_dir.glob("*.whl"))
-    compare_with_pip("popular", wheels_paths, bin)
+    compare_with_pip_wheels("popular", wheels_paths, bin)
 
 
 if __name__ == "__main__":

--- a/test/install/test_popular.py
+++ b/test/install/test_popular.py
@@ -5,7 +5,7 @@ Test with the top 100 pypi wheels and some more
 from subprocess import check_call
 
 from test.install.test_compare_pip import compare_with_pip_wheels
-from test.install.utils import get_bin, get_root
+from test.install.utils import get_root
 
 
 def test_popular():
@@ -22,9 +22,8 @@ def test_popular():
                 get_root().joinpath("test-data").joinpath("popular.txt"),
             ]
         )
-    bin = get_bin()
     wheels_paths = list(wheels_dir.glob("*.whl"))
-    compare_with_pip_wheels("popular", wheels_paths, bin)
+    compare_with_pip_wheels("popular", wheels_paths)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The added test compares pip's with monotrail's requirements.txt installation and checks that filenames and file contents are identical to the point that that makes sense.

The current test setup has two problems, namely that it's slow and that it uses the internet for both pip and monotrail. This is more realistic (when pypi changes our tests start pick that up), but also fragile and slow. It would be cool to have both pip and monotrail use a local cache or a proxy. For pip i don't know how to coerce it into using fixed data except starting or own pypi mirror/proxy, for monotrail we should eiter use a request mock or a local cache dir with a no refresh option.
