### PR TITLE
Try different clippy setup on github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - uses: giraffate/clippy-action@v1
         with:
           reporter: 'github-pr-check'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: giraffate/clippy-action@v1
         with:
-          reporter: 'github-pr-check'
+          reporter: 'github-pr-review'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           clippy_flags: --tests --all-features --workspace -- -D warnings
           fail_on_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Clippy
-        run: cargo clippy --tests --all-features --workspace -- -D warnings
+      - uses: giraffate/clippy-action@v1
+        with:
+          reporter: 'github-pr-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --tests --all-features --workspace -- -D warnings
+          fail_on_error: true
 
   black:
     name: Black

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -375,7 +375,7 @@ pub fn install(
         &specs,
         &location,
         &compatible_tags,
-        compile,
+        compile.clone(),
         false,
         no_parallel,
     )?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -375,7 +375,7 @@ pub fn install(
         &specs,
         &location,
         &compatible_tags,
-        compile.clone(),
+        compile,
         false,
         no_parallel,
     )?;


### PR DESCRIPTION
https://github.com/giraffate/clippy-action can show clippy errors as annotation or as pr review, which is nice because it avoids having to go into raw logs when looking into a CI failure. I unfortunately haven't found something comparable for `cargo test`.